### PR TITLE
expose prop definition type so it can be used externally

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@ import {
   FunctionComponent as uFunctionComponent,
   ComponentOptions as uComponentOptions,
   ICustomElement as uICustomElement,
-  PropsDefinitionInput as uPropsDefinitionInput
+  PropsDefinitionInput as uPropsDefinitionInput,
+  PropDefinition as uPropDefinition
 } from "./utils";
 
 export type ComponentOptions = uComponentOptions;
@@ -19,6 +20,7 @@ export type RegisterOptions = {
   BaseElement?: typeof HTMLElement;
   extension?: { extends: string };
 };
+export type PropDefinition<T> = uPropDefinition<T>;
 
 export function register<T>(
   tag: string,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-interface PropDefinition<T> {
+export interface PropDefinition<T> {
   value: T;
   attribute: string;
   notify: boolean;


### PR DESCRIPTION
At the moment i simply copy-pasted the type definition, but is is obviously ugly.
This fixes the issue, by exporting it.

Fixes #19 