### PR TITLE
feat: allow passing CustomElementRegistry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "component-register",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "component-register",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.24.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export type ICustomElement = uICustomElement;
 export type RegisterOptions = {
   BaseElement?: typeof HTMLElement;
   extension?: { extends: string };
+  customElements?: CustomElementRegistry;
 };
 export type PropDefinition<T> = uPropDefinition<T>;
 
@@ -27,7 +28,11 @@ export function register<T>(
   props = {} as PropsDefinitionInput<T>,
   options: RegisterOptions = {}
 ) {
-  const { BaseElement = HTMLElement, extension } = options;
+  const {
+    BaseElement = HTMLElement,
+    extension,
+    customElements = window.customElements
+  } = options;
   return (ComponentType: ComponentType<T>) => {
     if (!tag) throw new Error("tag is required to register a Component");
     let ElementType = customElements.get(tag);


### PR DESCRIPTION
Allows passing a CustomElementRegistry to use for registering the web component. This is useful when working with custom elements with something like JSDOM, where you have a document with a window that is not the browser global window.