### PR TITLE
next: avoids transforming case and dashes for attributes/properties

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,8 +54,6 @@ export {
   isConstructor,
   isObject,
   isFunction,
-  toAttribute,
-  toProperty,
   reloadElement
 } from "./utils";
 export { createMixin, compose } from "./mixin";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,7 +63,7 @@ export function normalizePropDefs<T>(
     memo[k] = !(isObject(v) && "value" in (v as object))
       ? ({ value: v } as unknown as PropDefinition<T[keyof T]>)
       : (v as PropDefinition<T[keyof T]>);
-    memo[k].attribute || (memo[k].attribute = toAttribute(k as string));
+    memo[k].attribute || (memo[k].attribute = (k as string));
     memo[k].parse =
       "parse" in memo[k] ? memo[k].parse : typeof memo[k].value !== "string";
     return memo;
@@ -136,19 +136,6 @@ export function reflect<T>(
   if (reflect === "true") reflect = "";
   node.setAttribute(attribute, reflect);
   Promise.resolve().then(() => delete node.__updating[attribute]);
-}
-
-export function toAttribute(propName: string) {
-  return propName
-    .replace(/\.?([A-Z]+)/g, (x, y) => "-" + y.toLowerCase())
-    .replace("_", "-")
-    .replace(/^-/, "");
-}
-
-export function toProperty(attr: string) {
-  return attr
-    .toLowerCase()
-    .replace(/(-)([a-z])/g, (test) => test.toUpperCase().replace("-", ""));
 }
 
 export function isObject(obj: any) {

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,7 +1,0 @@
-const { toProperty } = require("../lib/component-register");
-
-describe('Test Helpers', () => {
-  it('should convert attribute to Property name', () => {
-    expect(toProperty('my-custom-attribute')).toBe('myCustomAttribute');
-  })
-})


### PR DESCRIPTION
Related to https://github.com/ryansolid/dom-expressions/pull/373

We avoid transforming attributes to lowercase and also transforming `dashed-case` to `camelCase`

Note: 
- `toAttribute` and `toProperty` are no longer exported, I am not sure if this affects other packages? 
- `src/index.ts` had windows line endings, I tried to keep it like that but editor insisted on changing to unix line endings so well, this link shows the diff without the whitespace change https://github.com/ryansolid/component-register/pull/32/files?w=1